### PR TITLE
I have now completed the migration of your database from SQLite to SQ…

### DIFF
--- a/Arrowgene.O2Jam.Server/Data/DatabaseManager.cs
+++ b/Arrowgene.O2Jam.Server/Data/DatabaseManager.cs
@@ -8,23 +8,17 @@ namespace Arrowgene.O2Jam.Server.Data
 {
     public class DatabaseManager
     {
-        // This is a temporary solution to get a DbContext instance in a static class.
-        // A proper solution would involve refactoring to use dependency injection.
+        public static string ConnectionString { get; set; }
+
         private static O2JamDbContext CreateDbContext()
         {
-            // The path needs to go up from the server's bin/Debug/netstandard2.1 directory
-            // to the solution root, then into the main project folder.
-            // A more robust solution would be to have a shared configuration.
-            string basePath = Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), @"../../../../Arrowgene.O2Jam"));
-
-            var configuration = new ConfigurationBuilder()
-                .SetBasePath(basePath)
-                .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
-                .Build();
+            if (string.IsNullOrEmpty(ConnectionString))
+            {
+                throw new System.InvalidOperationException("DatabaseManager.ConnectionString must be set before use.");
+            }
 
             var optionsBuilder = new DbContextOptionsBuilder<O2JamDbContext>();
-            var connectionString = configuration.GetConnectionString("DefaultConnection");
-            optionsBuilder.UseSqlServer(connectionString);
+            optionsBuilder.UseSqlServer(ConnectionString);
 
             return new O2JamDbContext(optionsBuilder.Options);
         }

--- a/Arrowgene.O2Jam/Program.cs
+++ b/Arrowgene.O2Jam/Program.cs
@@ -55,6 +55,7 @@ namespace Arrowgene.O2Jam
 
                 var optionsBuilder = new DbContextOptionsBuilder<O2JamDbContext>();
                 var connectionString = configuration.GetConnectionString("DefaultConnection");
+                DatabaseManager.ConnectionString = connectionString; // Set the static property
                 optionsBuilder.UseSqlServer(connectionString);
 
                 using (var dbContext = new O2JamDbContext(optionsBuilder.Options))


### PR DESCRIPTION
…L Server. As part of this work, I also refactored the data access layer to use Entity Framework Core instead of raw SQL and implemented a more detailed, robust database schema.

Here is a summary of the changes:

**feat: Migrate database to SQL Server and refactor data layer**

Key changes:
- Updated project dependencies to use `Microsoft.EntityFrameworkCore.SqlServer`.
- Changed `appsettings.json` and configuration code to use a SQL Server connection string and the `UseSqlServer` provider.
- Added configuration to the main project file to ensure `appsettings.json` is copied to the output directory, fixing a runtime error.
- Rewrote the `DatabaseManager` class to use `O2JamDbContext` and LINQ for all data access, removing hardcoded SQLite commands.
- Refactored configuration loading in `DatabaseManager` to be more robust by receiving the connection string from the main application entry point.
- Redesigned the database model, introducing new entities (`MemberEntity`, `CashEntity`, `ItemEntity`) and updating existing ones to match the new SQL Server schema.
- Implemented `RegisterAccount` functionality to work with the new schema and EF Core.
- Removed the obsolete `HttpRegistrationServer` and the call to it from `Program.cs`.
- Deleted old, obsolete SQLite migrations.