### PR TITLE
fix: Implement MD5 password hashing for login

### DIFF
--- a/Arrowgene.O2Jam.Server/Data/DatabaseManager.cs
+++ b/Arrowgene.O2Jam.Server/Data/DatabaseManager.cs
@@ -29,7 +29,7 @@ namespace Arrowgene.O2Jam.Server.Data
             {
                 // Find user in 'member' table by username and password, trimming whitespace from the CHAR columns
                 var member = context.Members
-                    .FirstOrDefault(m => m.UserId.Trim() == username && m.Password.Trim() == password);
+                    .FirstOrDefault(m => m.UserId.Trim() == username && m.Password.Trim().ToLower() == password);
 
                 if (member == null)
                 {

--- a/Arrowgene.O2Jam.Server/PacketHandle/LoginHandle.cs
+++ b/Arrowgene.O2Jam.Server/PacketHandle/LoginHandle.cs
@@ -23,10 +23,20 @@ namespace Arrowgene.O2Jam.Server.PacketHandle
 
             Logger.Info($"Login attempt from game client: User='{username}'");
 
+            // Hash the password using MD5, as it's likely stored hashed in the database.
+            string hashedPassword;
+            using (var md5 = System.Security.Cryptography.MD5.Create())
+            {
+                var inputBytes = System.Text.Encoding.ASCII.GetBytes(password);
+                var hashBytes = md5.ComputeHash(inputBytes);
+                hashedPassword = Convert.ToHexString(hashBytes).ToLower();
+            }
+            Logger.Info($"Hashed password (MD5): {hashedPassword}");
+
             Account account;
             try
             {
-                account = DatabaseManager.GetAccount(username, password);
+                account = DatabaseManager.GetAccount(username, hashedPassword);
             }
             catch (Microsoft.Data.SqlClient.SqlException ex)
             {


### PR DESCRIPTION
This commit addresses the "Invalid credentials" error during login.

- The `LoginHandle` now hashes the incoming password from the client using MD5 before sending it to the `DatabaseManager`. This is a standard practice for older game servers where passwords are not stored in plain text.
- The `DatabaseManager` now performs a case-insensitive comparison for the password hash.