### PR TITLE
fix: Hash password on registration to match login

### DIFF
--- a/Arrowgene.O2Jam.Server/Data/DatabaseManager.cs
+++ b/Arrowgene.O2Jam.Server/Data/DatabaseManager.cs
@@ -69,11 +69,19 @@ namespace Arrowgene.O2Jam.Server.Data
                     try
                     {
                         // 2. Create and save the new member to get an ID
+                        string hashedPassword;
+                        using (var md5 = System.Security.Cryptography.MD5.Create())
+                        {
+                            var inputBytes = System.Text.Encoding.ASCII.GetBytes(password);
+                            var hashBytes = md5.ComputeHash(inputBytes);
+                            hashedPassword = System.Convert.ToHexString(hashBytes).ToLower();
+                        }
+
                         var newMember = new MemberEntity
                         {
                             UserId = username,
                             UserNick = username, // Default nickname to username
-                            Password = password,
+                            Password = hashedPassword,
                             Sex = true, // Default to male
                             RegisterDate = System.DateTime.UtcNow,
                             Id9you = "0", // Default value


### PR DESCRIPTION
This commit fixes a critical bug where the registration process was storing passwords in plain text, while the login process expected MD5-hashed passwords. This caused all newly registered accounts to be unable to log in.

- The `DatabaseManager.RegisterAccount` method now hashes the password using MD5 before saving it to the database, ensuring consistency with the login logic.