### PR TITLE
Feat: Add connection string logging

### DIFF
--- a/Arrowgene.O2Jam/Program.cs
+++ b/Arrowgene.O2Jam/Program.cs
@@ -55,6 +55,7 @@ namespace Arrowgene.O2Jam
 
                 var optionsBuilder = new DbContextOptionsBuilder<O2JamDbContext>();
                 var connectionString = configuration.GetConnectionString("DefaultConnection");
+                Logger.Info($"Database Connection String: '{connectionString}'"); // Log the connection string
                 DatabaseManager.ConnectionString = connectionString; // Set the static property
                 optionsBuilder.UseSqlServer(connectionString);
 


### PR DESCRIPTION
Adds a log message at server startup that displays the database connection string being used.

This will help administrators and developers to easily diagnose database connection issues by verifying that the server is loading the correct configuration from `appsettings.json`.