### PR TITLE
Fix: Use SET IDENTITY_INSERT to allow on-the-fly user creation

### DIFF
--- a/Arrowgene.O2Jam.Server/Data/DatabaseManager.cs
+++ b/Arrowgene.O2Jam.Server/Data/DatabaseManager.cs
@@ -121,7 +121,11 @@ namespace Arrowgene.O2Jam.Server.Data
                             };
                             context.Items.Add(newItems);
 
+                            // Allow explicit identity insert for T_o2jam_userinfo
+                            context.Database.ExecuteSqlRaw("SET IDENTITY_INSERT dbo.T_o2jam_userinfo ON;");
                             context.SaveChanges();
+                            context.Database.ExecuteSqlRaw("SET IDENTITY_INSERT dbo.T_o2jam_userinfo OFF;");
+
                             transaction.Commit();
 
                             // Set the user to the newly created user info
@@ -130,6 +134,8 @@ namespace Arrowgene.O2Jam.Server.Data
                         }
                         catch (System.Exception ex)
                         {
+                            // Ensure IDENTITY_INSERT is turned off in case of an error
+                            context.Database.ExecuteSqlRaw("SET IDENTITY_INSERT dbo.T_o2jam_userinfo OFF;");
                             var errorMsg = ex.InnerException != null ? ex.InnerException.Message : ex.Message;
                             Logger.Error($"Login Error: Failed to create missing data for '{username}'. Error: {errorMsg}");
                             transaction.Rollback();


### PR DESCRIPTION
This commit provides the definitive fix for a database write error that occurred when creating user data for an externally registered account.

The previous fix corrected the Entity Framework Core entity definition but did not account for the database-level requirement to explicitly allow identity insertion.

This patch modifies `DatabaseManager.cs` to wrap the `SaveChanges()` call with `SET IDENTITY_INSERT dbo.T_o2jam_userinfo ON;` and `SET IDENTITY_INSERT dbo.T_o2jam_userinfo OFF;`. This command is now also executed in the `catch` block to ensure it is always turned off, even on failure.

This change, combined with the previous entity definition correction, will allow the server to successfully create missing user records by inserting the correct primary key value from the `member` table.