### PR TITLE
Fix: Prevent client crash when entering lobby

### DIFF
--- a/Arrowgene.O2Jam.Server/PacketHandle/CharacterHandle.cs
+++ b/Arrowgene.O2Jam.Server/PacketHandle/CharacterHandle.cs
@@ -59,7 +59,7 @@ namespace Arrowgene.O2Jam.Server.PacketHandle
             res.WriteInt32(character.CostumeProps);
             res.WriteInt32(character.Shoes);
 
-            res.WriteInt32(35); // val2, appears to be a static value from reference. Keep it for now.
+            res.WriteInt32(character.Earring); // This was hardcoded to 35. It should be the face ID, which is stored in Earring (Equip12).
 
             // Equipped Items Block 2 (5 items)
             res.WriteInt32(character.Wing);


### PR DESCRIPTION
Resolves an issue where the game client would crash upon entering the lobby after a character was created on-the-fly.

The crash was caused by a hardcoded value (35) being sent in the `CharacterRes` packet instead of the character's actual face ID. This was correct for male characters (face ID 35) but caused a crash for female characters (face ID 2).

This patch modifies `CharacterHandle.cs` to send the dynamic face ID (from `character.Earring`, which maps to `Equip12`) in the character data packet. This ensures the correct data is sent for all characters.