### PR TITLE
Fix: Correct character data to prevent lobby crash

### DIFF
--- a/Arrowgene.O2Jam.Server/Data/DatabaseManager.cs
+++ b/Arrowgene.O2Jam.Server/Data/DatabaseManager.cs
@@ -87,7 +87,7 @@ namespace Arrowgene.O2Jam.Server.Data
                                 UserId = usernameStr,
                                 UserNickname = usernickStr,
                                 Sex = member.Sex,
-                                Level = 1,
+                                Level = 0,
                                 Experience = 0,
                                 AdminLevel = 0,
                                 Battle = 0,

--- a/Arrowgene.O2Jam.Server/PacketHandle/CharacterHandle.cs
+++ b/Arrowgene.O2Jam.Server/PacketHandle/CharacterHandle.cs
@@ -35,7 +35,7 @@ namespace Arrowgene.O2Jam.Server.PacketHandle
             res.WriteByte((byte)character.Gender); // Gender from DB
             res.WriteInt32(0); // Unknown field, keep as 0
             res.WriteInt32(0); // Unknown field, keep as 0
-            res.WriteInt32(character.Cash); // Cash Point from DB
+            res.WriteInt32(character.Gems); // Gem Point from DB
 
             // Player Stats
             res.WriteInt32(character.Level); // Level from DB


### PR DESCRIPTION
Resolves a client crash that occurred upon entering the lobby. The crash was caused by incorrect character data being sent by the server for on-the-fly created users.

This commit includes two main corrections:
1.  **Default Level:** In `DatabaseManager.cs`, the default level for new characters is now correctly set to `0` instead of `1`, matching the logic in the game's original stored procedures.
2.  **Currency Data:** In `CharacterHandle.cs`, the character data packet is now correctly populated with both GEM and MCASH values (`character.Gems` and `character.Cash`) in their respective fields, instead of sending one value twice.

These changes ensure the character data sent to the client is valid and consistent with the game's expectations.