### PR TITLE
Fix: Align CharacterHandle with user-provided reference

### DIFF
--- a/Arrowgene.O2Jam.Server/PacketHandle/CharacterHandle.cs
+++ b/Arrowgene.O2Jam.Server/PacketHandle/CharacterHandle.cs
@@ -35,7 +35,7 @@ namespace Arrowgene.O2Jam.Server.PacketHandle
             res.WriteByte((byte)character.Gender); // Gender from DB
             res.WriteInt32(0); // Unknown field, keep as 0
             res.WriteInt32(0); // Unknown field, keep as 0
-            res.WriteInt32(character.Gems); // Gem Point from DB
+            res.WriteInt32(character.Cash); // Cash Point from DB
 
             // Player Stats
             res.WriteInt32(character.Level); // Level from DB
@@ -59,7 +59,7 @@ namespace Arrowgene.O2Jam.Server.PacketHandle
             res.WriteInt32(character.CostumeProps);
             res.WriteInt32(character.Shoes);
 
-            res.WriteInt32(character.Earring); // This was hardcoded to 35. It should be the face ID, which is stored in Earring (Equip12).
+            res.WriteInt32(35); // val2, appears to be a static value from reference. Keep it for now.
 
             // Equipped Items Block 2 (5 items)
             res.WriteInt32(character.Wing);


### PR DESCRIPTION
Resolves a client crash issue by modifying the character data packet to match a user-provided code sample.

Previous attempts to logically deduce the packet structure were unsuccessful. This commit reverts those changes and implements the structure from the reference code.

The changes in `CharacterHandle.cs` include:
1.  Setting the first currency field to use `character.Cash`.
2.  Setting a specific field after the first item block to a hardcoded value of `35`.

This aligns the sent data with what is presumed to be a working configuration for the client.