### PR TITLE
Fix: Correct item ID data types in character packet

### DIFF
--- a/Arrowgene.O2Jam.Server/PacketHandle/ChannelHandle.cs
+++ b/Arrowgene.O2Jam.Server/PacketHandle/ChannelHandle.cs
@@ -52,26 +52,26 @@ namespace Arrowgene.O2Jam.Server.PacketHandle
             charRes.WriteInt32(0); // Unknown
             charRes.WriteByte(0);  // Unknown
 
-            // Equipped Items
-            charRes.WriteInt32(character.Instrument);
-            charRes.WriteInt32(character.Hat);
-            charRes.WriteInt32(character.Props);
-            charRes.WriteInt32(character.Glove);
-            charRes.WriteInt32(character.Necklace);
-            charRes.WriteInt32(character.Top);
-            charRes.WriteInt32(character.Bottom);
-            charRes.WriteInt32(character.Glasses);
-            charRes.WriteInt32(character.Earring);
-            charRes.WriteInt32(character.CostumeProps);
-            charRes.WriteInt32(character.Shoes);
-            charRes.WriteInt32(character.Earring); // Face ID
+            // Equipped Items - These must be Int16 (short) to match the DB schema
+            charRes.WriteInt16((short)character.Instrument);
+            charRes.WriteInt16((short)character.Hat);
+            charRes.WriteInt16((short)character.Props);
+            charRes.WriteInt16((short)character.Glove);
+            charRes.WriteInt16((short)character.Necklace);
+            charRes.WriteInt16((short)character.Top);
+            charRes.WriteInt16((short)character.Bottom);
+            charRes.WriteInt16((short)character.Glasses);
+            charRes.WriteInt16((short)character.Earring);
+            charRes.WriteInt16((short)character.CostumeProps);
+            charRes.WriteInt16((short)character.Shoes);
+            charRes.WriteInt16((short)character.Earring); // Face ID
 
             // Equipped Items Block 2
-            charRes.WriteInt32(character.Wing);
-            charRes.WriteInt32(character.InstrumentProps);
-            charRes.WriteInt32(character.Pet);
-            charRes.WriteInt32(character.HairAccessory);
-            charRes.WriteInt32(character.SetAccessory);
+            charRes.WriteInt16((short)character.Wing);
+            charRes.WriteInt16((short)character.InstrumentProps);
+            charRes.WriteInt16((short)character.Pet);
+            charRes.WriteInt16((short)character.HairAccessory);
+            charRes.WriteInt16((short)character.SetAccessory);
 
             // My Bag (Inventory)
             charRes.WriteInt32(1);


### PR DESCRIPTION
Resolves a persistent client crash that occurred upon entering the lobby.

After extensive debugging, the root cause was identified as a data type mismatch between the server and the client. The server was sending equipped item IDs as 4-byte integers (`Int32`), while the database schema defines them as `smallint` (2-bytes), which the client expects. This mismatch corrupted the data packet from the client's perspective, causing a crash.

This commit modifies `ChannelHandle.cs` to write all 17 equipped item fields using `WriteInt16` instead of `WriteInt32`. This aligns the packet structure perfectly with the database schema and the client's expectations.

This commit represents the definitive fix for the character-related lobby crash.